### PR TITLE
Bug: Fix VerifiedUser cache invalidation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='django-waffle-session',
-    version='0.2.6',
+    version='0.2.7',
     description='A feature flipper for Django.',
     long_description=open('README.rst').read(),
     author='Francis Mwangi',

--- a/waffle/models.py
+++ b/waffle/models.py
@@ -183,7 +183,7 @@ def cache_verified_user(**kwargs):
 
 def uncache_verified_user(**kwargs):
     verified_user = kwargs.get('instance')
-    cache.delete(keyfmt(settings.VERIFIED_USER_CACHE_KEY, verified_user.phone_number))
+    cache.set(keyfmt(settings.VERIFIED_USER_CACHE_KEY, verified_user.phone_number), None, 5)
 
 
 post_delete.connect(uncache_verified_user, sender=VerifiedUser,


### PR DESCRIPTION
Invalidate VerifiedUsers cache by setting relevant key to None instead of using cache.delete(). cache.delete() was causing unit tests to fail in library clients.